### PR TITLE
Filling two variables of a substrate of the original of a Result

### DIFF
--- a/include/util/MediaConverter.h
+++ b/include/util/MediaConverter.h
@@ -92,6 +92,6 @@ namespace cvac
                  const string& _desAbsDir,
                  const string& _desFilename,
                  vector<string>& _resFilename,
-                 vector<string>& _resAuxInfo);
+                 vector<string>& _resFrameInfo);
   };
 }

--- a/include/util/RunSetIterator.h
+++ b/include/util/RunSetIterator.h
@@ -72,7 +72,6 @@ namespace cvac
       mimeTypes.clear();
     }
   };
-
 //--------------------------------------------------------------------------- 
 
   class RunSetIterator
@@ -119,7 +118,6 @@ namespace cvac
                              const rsMediaType& _targerType,
                              MediaConverter* _pConv,
                              const string& _rDirTemp,int _originalIdx);
-    rsMediaType getType(const LabelablePtr _pla);
     bool matchPurpose(int origIdx);
     LabelablePtr cloneLabelablePtr(const LabelablePtr _pla, int frameNum);
 

--- a/include/util/RunSetWrapper.h
+++ b/include/util/RunSetWrapper.h
@@ -71,10 +71,14 @@ namespace cvac
     ServiceManager* mServiceMan;
     ResultSet mResultSet;		//candidate list of LabelablePtr		      
     vector<rsMediaType> mResultSetType;
+    std::vector<std::string> mTypeMacro;
+    std::vector<std::string> mTypeMacro_Image;  //for the func. getTypeMacro
+    std::vector<std::string> mTypeMacro_Video;  //for the func. getTypeMacro
   
   private:	//Basic Utility	 
-    rsMediaType getType(const string _aPath);
-    rsMediaType getType(const LabelablePtr _pla);
+    std::string getTypeMacro(const std::string& _path);//image,video and etc
+    rsMediaType getTypeMicro(const string _aPath);//in detail: bmp, png, and so on.
+    rsMediaType getTypeMicro(const LabelablePtr _pla);
     string convertToAbsDirectory(const string& _directory);
     string convertToAbsDirectory(const string& _directory,
                                     const string& _prefix);      
@@ -85,8 +89,8 @@ namespace cvac
                            const vector<rsMediaType>& _types,
                            rsMediaType& _resType);    
   private:	//main functions
-    void addToList(const LabelablePtr _pla,const rsMediaType _type, 
-                     cvac::Purpose);
+    void addToList(const LabelablePtr _pla,const rsMediaType _type,
+                   cvac::Purpose);
     bool makeBasicList();	
     bool makeBasicList_parse(const string& _absDir,bool _recursive,
                              const string& _relDir,

--- a/src/util/MediaConverter.cpp
+++ b/src/util/MediaConverter.cpp
@@ -63,7 +63,7 @@ bool MediaConverter_openCV_i2i::convert(const string& _srcAbsPath,
   cv::Mat tImg = cv::imread(_srcAbsPath);
   if(tImg.empty())
   {    
-    localAndClientMsg(VLogger::WARN, NULL,"Conversion error from %s to %s.\n",
+    localAndClientMsg(VLogger::ERROR, NULL,"Conversion error from %s to %s.\n",
       _srcAbsPath.c_str(),tDesPath.c_str());
     return false;
   }
@@ -100,9 +100,9 @@ bool MediaConverter_openCV_v2i::convert(const string& _srcAbsPath,
                                         const string& _desAbsDir,
                                         const string& _desFilename,
                                         vector<string>& _resFilename,
-                                        vector<string>& _resAuxInfo)
+                                        vector<string>& _resFrameInfo)
 {
-  _resAuxInfo.clear();
+  _resFrameInfo.clear();
   _resFilename.clear();
    string tDesAbsPath = _desAbsDir + "/" + _desFilename;
 
@@ -117,7 +117,7 @@ bool MediaConverter_openCV_v2i::convert(const string& _srcAbsPath,
     tnFrame = (long)mVideoFile.get(CV_CAP_PROP_FRAME_COUNT);
   else
   {
-    localAndClientMsg(VLogger::WARN, NULL,"Conversion error from %s to %s.\n",
+    localAndClientMsg(VLogger::ERROR, NULL,"Conversion error from %s to %s.\n",
       _srcAbsPath.c_str(),tDesAbsPath.c_str());
     return false;
   }
@@ -161,7 +161,7 @@ bool MediaConverter_openCV_v2i::convert(const string& _srcAbsPath,
         if(imwrite(tDesAbsPath,tMatFrame))
         {
           _resFilename.push_back(tfileNameNew);
-          _resAuxInfo.push_back(ss.str());
+          _resFrameInfo.push_back(ss.str());
         }
         else
         {

--- a/src/util/RunSetIterator.cpp
+++ b/src/util/RunSetIterator.cpp
@@ -159,6 +159,9 @@ bool RunSetIterator::makeList(ResultSet& _resultSet,
             mConvertibleItr->second,mMediaTempDirectory,k))
           {
             //this case may be very rare: error while converting, stopping by user interruption
+            localAndClientMsg(VLogger::ERROR, mCallback2Client,
+              "Conversion is stopped by error or user interruption for %s.\n",
+              (_resultSet.results[k].original)->sub.path.filename.c_str());
             return false;
           }
 
@@ -259,6 +262,8 @@ bool RunSetIterator::convertAndAddToList(const LabelablePtr& _pla,
   vector<string> tAuxInfo;
   if(_pConv->convert(tAbsPathOld,tAbsDirNew,tFileNameNew,tListFileName,tAuxInfo))
   {
+    //if tAuxInfo is not empty, above conversion comes from "video2image"
+    //the variable "tAuxInfo" includes frame numbers
     vector<string>::iterator tItrFilename = tListFileName.begin();
     for(int _idx=0;tItrFilename!=tListFileName.end();tItrFilename++,_idx++)
     {
@@ -271,17 +276,18 @@ bool RunSetIterator::convertAndAddToList(const LabelablePtr& _pla,
       int frameNum = -1;
       if(!tAuxInfo.empty())
           frameNum = atoi(tAuxInfo[_idx].c_str());
+      
       LabelablePtr _la = cloneLabelablePtr(_pla, frameNum);
       _la->sub.isImage = true;
+      //currently, conversion target is only an image.
+      //refer to the function in RunSetWrapper: getTypeMacro
       _la->sub.isVideo = !(_la->sub.isImage);
       _la->sub.path.filename = (*tItrFilename);
       _la->sub.path.directory.relativePath = tRDirNew;
+      _la->lab.hasLabel = false;
 
       if(!tAuxInfo.empty())
-      {
-        _la->lab.hasLabel = false;  
         _la->lab.name = tAuxInfo[_idx];
-      }
       else
         _la->lab.name = "";
       /*
@@ -418,216 +424,41 @@ ResultSet& RunSetIterator::getResultSet()
 
 void RunSetIterator::makeConversionList()
 {  
-  mConvertible["bmp2dib"] = mConv_openCV_i2i;
-  mConvertible["bmp2jpeg"] = mConv_openCV_i2i;
-  mConvertible["bmp2jpg"] = mConv_openCV_i2i;
-  mConvertible["bmp2jpe"] = mConv_openCV_i2i;
-  mConvertible["bmp2jp2"] = mConv_openCV_i2i;
-  mConvertible["bmp2png"] = mConv_openCV_i2i;
-  mConvertible["bmp2pbm"] = mConv_openCV_i2i;
-  mConvertible["bmp2pgm"] = mConv_openCV_i2i;
-  mConvertible["bmp2ppm"] = mConv_openCV_i2i;
-  mConvertible["bmp2sr"] = mConv_openCV_i2i;
-  mConvertible["bmp2ras"] = mConv_openCV_i2i;
-  mConvertible["bmp2tiff"] = mConv_openCV_i2i;
-  mConvertible["bmp2tif"] = mConv_openCV_i2i;
-  mConvertible["dib2bmp"] = mConv_openCV_i2i;
-  mConvertible["dib2jpeg"] = mConv_openCV_i2i;
-  mConvertible["dib2jpg"] = mConv_openCV_i2i;
-  mConvertible["dib2jpe"] = mConv_openCV_i2i;
-  mConvertible["dib2jp2"] = mConv_openCV_i2i;
-  mConvertible["dib2png"] = mConv_openCV_i2i;
-  mConvertible["dib2pbm"] = mConv_openCV_i2i;
-  mConvertible["dib2pgm"] = mConv_openCV_i2i;
-  mConvertible["dib2ppm"] = mConv_openCV_i2i;
-  mConvertible["dib2sr"] = mConv_openCV_i2i;
-  mConvertible["dib2ras"] = mConv_openCV_i2i;
-  mConvertible["dib2tiff"] = mConv_openCV_i2i;
-  mConvertible["dib2tif"] = mConv_openCV_i2i;
-  mConvertible["jpeg2bmp"] = mConv_openCV_i2i;
-  mConvertible["jpeg2dib"] = mConv_openCV_i2i;
-  mConvertible["jpeg2jpg"] = mConv_openCV_i2i;
-  mConvertible["jpeg2jpe"] = mConv_openCV_i2i;
-  mConvertible["jpeg2jp2"] = mConv_openCV_i2i;
-  mConvertible["jpeg2png"] = mConv_openCV_i2i;
-  mConvertible["jpeg2pbm"] = mConv_openCV_i2i;
-  mConvertible["jpeg2pgm"] = mConv_openCV_i2i;
-  mConvertible["jpeg2ppm"] = mConv_openCV_i2i;
-  mConvertible["jpeg2sr"] = mConv_openCV_i2i;
-  mConvertible["jpeg2ras"] = mConv_openCV_i2i;
-  mConvertible["jpeg2tiff"] = mConv_openCV_i2i;
-  mConvertible["jpeg2tif"] = mConv_openCV_i2i;
-  mConvertible["jpg2bmp"] = mConv_openCV_i2i;
-  mConvertible["jpg2dib"] = mConv_openCV_i2i;
-  mConvertible["jpg2jpeg"] = mConv_openCV_i2i;
-  mConvertible["jpg2jpe"] = mConv_openCV_i2i;
-  mConvertible["jpg2jp2"] = mConv_openCV_i2i;
-  mConvertible["jpg2png"] = mConv_openCV_i2i;
-  mConvertible["jpg2pbm"] = mConv_openCV_i2i;
-  mConvertible["jpg2pgm"] = mConv_openCV_i2i;
-  mConvertible["jpg2ppm"] = mConv_openCV_i2i;
-  mConvertible["jpg2sr"] = mConv_openCV_i2i;
-  mConvertible["jpg2ras"] = mConv_openCV_i2i;
-  mConvertible["jpg2tiff"] = mConv_openCV_i2i;
-  mConvertible["jpg2tif"] = mConv_openCV_i2i;
-  mConvertible["jpe2bmp"] = mConv_openCV_i2i;
-  mConvertible["jpe2dib"] = mConv_openCV_i2i;
-  mConvertible["jpe2jpeg"] = mConv_openCV_i2i;
-  mConvertible["jpe2jpg"] = mConv_openCV_i2i;
-  mConvertible["jpe2jp2"] = mConv_openCV_i2i;
-  mConvertible["jpe2png"] = mConv_openCV_i2i;
-  mConvertible["jpe2pbm"] = mConv_openCV_i2i;
-  mConvertible["jpe2pgm"] = mConv_openCV_i2i;
-  mConvertible["jpe2ppm"] = mConv_openCV_i2i;
-  mConvertible["jpe2sr"] = mConv_openCV_i2i;
-  mConvertible["jpe2ras"] = mConv_openCV_i2i;
-  mConvertible["jpe2tiff"] = mConv_openCV_i2i;
-  mConvertible["jpe2tif"] = mConv_openCV_i2i;
-  mConvertible["jp22bmp"] = mConv_openCV_i2i;
-  mConvertible["jp22dib"] = mConv_openCV_i2i;
-  mConvertible["jp22jpeg"] = mConv_openCV_i2i;
-  mConvertible["jp22jpg"] = mConv_openCV_i2i;
-  mConvertible["jp22jpe"] = mConv_openCV_i2i;
-  mConvertible["jp22png"] = mConv_openCV_i2i;
-  mConvertible["jp22pbm"] = mConv_openCV_i2i;
-  mConvertible["jp22pgm"] = mConv_openCV_i2i;
-  mConvertible["jp22ppm"] = mConv_openCV_i2i;
-  mConvertible["jp22sr"] = mConv_openCV_i2i;
-  mConvertible["jp22ras"] = mConv_openCV_i2i;
-  mConvertible["jp22tiff"] = mConv_openCV_i2i;
-  mConvertible["jp22tif"] = mConv_openCV_i2i;
-  mConvertible["png2bmp"] = mConv_openCV_i2i;
-  mConvertible["png2dib"] = mConv_openCV_i2i;
-  mConvertible["png2jpeg"] = mConv_openCV_i2i;
-  mConvertible["png2jpg"] = mConv_openCV_i2i;
-  mConvertible["png2jpe"] = mConv_openCV_i2i;
-  mConvertible["png2jp2"] = mConv_openCV_i2i;
-  mConvertible["png2pbm"] = mConv_openCV_i2i;
-  mConvertible["png2pgm"] = mConv_openCV_i2i;
-  mConvertible["png2ppm"] = mConv_openCV_i2i;
-  mConvertible["png2sr"] = mConv_openCV_i2i;
-  mConvertible["png2ras"] = mConv_openCV_i2i;
-  mConvertible["png2tiff"] = mConv_openCV_i2i;
-  mConvertible["png2tif"] = mConv_openCV_i2i;
-  mConvertible["pbm2bmp"] = mConv_openCV_i2i;
-  mConvertible["pbm2dib"] = mConv_openCV_i2i;
-  mConvertible["pbm2jpeg"] = mConv_openCV_i2i;
-  mConvertible["pbm2jpg"] = mConv_openCV_i2i;
-  mConvertible["pbm2jpe"] = mConv_openCV_i2i;
-  mConvertible["pbm2jp2"] = mConv_openCV_i2i;
-  mConvertible["pbm2png"] = mConv_openCV_i2i;
-  mConvertible["pbm2pgm"] = mConv_openCV_i2i;
-  mConvertible["pbm2ppm"] = mConv_openCV_i2i;
-  mConvertible["pbm2sr"] = mConv_openCV_i2i;
-  mConvertible["pbm2ras"] = mConv_openCV_i2i;
-  mConvertible["pbm2tiff"] = mConv_openCV_i2i;
-  mConvertible["pbm2tif"] = mConv_openCV_i2i;
-  mConvertible["pgm2bmp"] = mConv_openCV_i2i;
-  mConvertible["pgm2dib"] = mConv_openCV_i2i;
-  mConvertible["pgm2jpeg"] = mConv_openCV_i2i;
-  mConvertible["pgm2jpg"] = mConv_openCV_i2i;
-  mConvertible["pgm2jpe"] = mConv_openCV_i2i;
-  mConvertible["pgm2jp2"] = mConv_openCV_i2i;
-  mConvertible["pgm2png"] = mConv_openCV_i2i;
-  mConvertible["pgm2pbm"] = mConv_openCV_i2i;
-  mConvertible["pgm2ppm"] = mConv_openCV_i2i;
-  mConvertible["pgm2sr"] = mConv_openCV_i2i;
-  mConvertible["pgm2ras"] = mConv_openCV_i2i;
-  mConvertible["pgm2tiff"] = mConv_openCV_i2i;
-  mConvertible["pgm2tif"] = mConv_openCV_i2i;
-  mConvertible["ppm2bmp"] = mConv_openCV_i2i;
-  mConvertible["ppm2dib"] = mConv_openCV_i2i;
-  mConvertible["ppm2jpeg"] = mConv_openCV_i2i;
-  mConvertible["ppm2jpg"] = mConv_openCV_i2i;
-  mConvertible["ppm2jpe"] = mConv_openCV_i2i;
-  mConvertible["ppm2jp2"] = mConv_openCV_i2i;
-  mConvertible["ppm2png"] = mConv_openCV_i2i;
-  mConvertible["ppm2pbm"] = mConv_openCV_i2i;
-  mConvertible["ppm2pgm"] = mConv_openCV_i2i;
-  mConvertible["ppm2sr"] = mConv_openCV_i2i;
-  mConvertible["ppm2ras"] = mConv_openCV_i2i;
-  mConvertible["ppm2tiff"] = mConv_openCV_i2i;
-  mConvertible["ppm2tif"] = mConv_openCV_i2i;
-  mConvertible["sr2bmp"] = mConv_openCV_i2i;
-  mConvertible["sr2dib"] = mConv_openCV_i2i;
-  mConvertible["sr2jpeg"] = mConv_openCV_i2i;
-  mConvertible["sr2jpg"] = mConv_openCV_i2i;
-  mConvertible["sr2jpe"] = mConv_openCV_i2i;
-  mConvertible["sr2jp2"] = mConv_openCV_i2i;
-  mConvertible["sr2png"] = mConv_openCV_i2i;
-  mConvertible["sr2pbm"] = mConv_openCV_i2i;
-  mConvertible["sr2pgm"] = mConv_openCV_i2i;
-  mConvertible["sr2ppm"] = mConv_openCV_i2i;
-  mConvertible["sr2ras"] = mConv_openCV_i2i;
-  mConvertible["sr2tiff"] = mConv_openCV_i2i;
-  mConvertible["sr2tif"] = mConv_openCV_i2i;
-  mConvertible["ras2bmp"] = mConv_openCV_i2i;
-  mConvertible["ras2dib"] = mConv_openCV_i2i;
-  mConvertible["ras2jpeg"] = mConv_openCV_i2i;
-  mConvertible["ras2jpg"] = mConv_openCV_i2i;
-  mConvertible["ras2jpe"] = mConv_openCV_i2i;
-  mConvertible["ras2jp2"] = mConv_openCV_i2i;
-  mConvertible["ras2png"] = mConv_openCV_i2i;
-  mConvertible["ras2pbm"] = mConv_openCV_i2i;
-  mConvertible["ras2pgm"] = mConv_openCV_i2i;
-  mConvertible["ras2ppm"] = mConv_openCV_i2i;
-  mConvertible["ras2sr"] = mConv_openCV_i2i;
-  mConvertible["ras2tiff"] = mConv_openCV_i2i;
-  mConvertible["ras2tif"] = mConv_openCV_i2i;
-  mConvertible["tiff2bmp"] = mConv_openCV_i2i;
-  mConvertible["tiff2dib"] = mConv_openCV_i2i;
-  mConvertible["tiff2jpeg"] = mConv_openCV_i2i;
-  mConvertible["tiff2jpg"] = mConv_openCV_i2i;
-  mConvertible["tiff2jpe"] = mConv_openCV_i2i;
-  mConvertible["tiff2jp2"] = mConv_openCV_i2i;
-  mConvertible["tiff2png"] = mConv_openCV_i2i;
-  mConvertible["tiff2pbm"] = mConv_openCV_i2i;
-  mConvertible["tiff2pgm"] = mConv_openCV_i2i;
-  mConvertible["tiff2ppm"] = mConv_openCV_i2i;
-  mConvertible["tiff2sr"] = mConv_openCV_i2i;
-  mConvertible["tiff2ras"] = mConv_openCV_i2i;
-  mConvertible["tiff2tif"] = mConv_openCV_i2i;
-  mConvertible["tif2bmp"] = mConv_openCV_i2i;
-  mConvertible["tif2dib"] = mConv_openCV_i2i;
-  mConvertible["tif2jpeg"] = mConv_openCV_i2i;
-  mConvertible["tif2jpg"] = mConv_openCV_i2i;
-  mConvertible["tif2jpe"] = mConv_openCV_i2i;
-  mConvertible["tif2jp2"] = mConv_openCV_i2i;
-  mConvertible["tif2png"] = mConv_openCV_i2i;
-  mConvertible["tif2pbm"] = mConv_openCV_i2i;
-  mConvertible["tif2pgm"] = mConv_openCV_i2i;
-  mConvertible["tif2ppm"] = mConv_openCV_i2i;
-  mConvertible["tif2sr"] = mConv_openCV_i2i;
-  mConvertible["tif2ras"] = mConv_openCV_i2i;
-  mConvertible["tif2tiff"] = mConv_openCV_i2i;
+  //assuming openCV
+  const std::string _supportedImage[] = {"bmp","dib","jpeg","jpg","jpe","jp2",
+                                         "png","pbm","pgm","ppm","sr","ras",
+                                         "tiff","tif"};
 
+  //assuming openCV
+  const std::string _supportedVideo[] = {"mpg","mpeg"};
 
-  mConvertible["mpg2bmp"] = mConv_openCV_v2i;
-  mConvertible["mpg2dib"] = mConv_openCV_v2i;
-  mConvertible["mpg2jpeg"] = mConv_openCV_v2i;
-  mConvertible["mpg2jpg"] = mConv_openCV_v2i;
-  mConvertible["mpg2jpe"] = mConv_openCV_v2i;
-  mConvertible["mpg2jp2"] = mConv_openCV_v2i;
-  mConvertible["mpg2png"] = mConv_openCV_v2i;
-  mConvertible["mpg2pbm"] = mConv_openCV_v2i;
-  mConvertible["mpg2pgm"] = mConv_openCV_v2i;
-  mConvertible["mpg2sr"] = mConv_openCV_v2i;
-  mConvertible["mpg2ras"] = mConv_openCV_v2i;
-  mConvertible["mpg2tiff"] = mConv_openCV_v2i;
-  mConvertible["mpg2tif"] = mConv_openCV_v2i;
+  vector<string> typeImage;
+  for(int k = 0;k<(sizeof(_supportedImage)/sizeof(_supportedImage[0]));k++)
+    typeImage.push_back(_supportedImage[k]);
 
-  mConvertible["mpeg2bmp"] = mConv_openCV_v2i;
-  mConvertible["mpeg2dib"] = mConv_openCV_v2i;
-  mConvertible["mpeg2jpeg"] = mConv_openCV_v2i;
-  mConvertible["mpeg2jpg"] = mConv_openCV_v2i;
-  mConvertible["mpeg2jpe"] = mConv_openCV_v2i;
-  mConvertible["mpeg2jp2"] = mConv_openCV_v2i;
-  mConvertible["mpeg2png"] = mConv_openCV_v2i;
-  mConvertible["mpeg2pbm"] = mConv_openCV_v2i;
-  mConvertible["mpeg2pgm"] = mConv_openCV_v2i;
-  mConvertible["mpeg2sr"] = mConv_openCV_v2i;
-  mConvertible["mpeg2ras"] = mConv_openCV_v2i;
-  mConvertible["mpeg2tiff"] = mConv_openCV_v2i;
-  mConvertible["mpeg2tif"] = mConv_openCV_v2i;
+  vector<string> typeVideo;
+  for(int k = 0;k<(sizeof(_supportedVideo)/sizeof(_supportedVideo[0]));k++)
+    typeVideo.push_back(_supportedVideo[k]);
+  
+  int i,j;
+  for(i=0;i<typeImage.size();i++)
+  {
+    for(j=0;j<typeImage.size();j++)
+    {
+	  if(i==j)
+	    continue;
+	  else
+	  {
+	    string msg = typeImage[i] + "2" + typeImage[j];
+		mConvertible[msg.c_str()] = mConv_openCV_i2i;
+	  }
+    }
+    
+    for(j=0;j<typeVideo.size();j++)
+    {
+	  string msg = typeVideo[j] + "2" + typeImage[i];
+	  mConvertible[msg.c_str()] = mConv_openCV_v2i;
+	}
+  }
 }
 

--- a/src/util/RunSetWrapper.cpp
+++ b/src/util/RunSetWrapper.cpp
@@ -40,6 +40,22 @@
 using namespace Ice;
 using namespace cvac;
 
+const std::string _typeMacro_Image[] = {"bmp","dib","jpeg","jpg","jpe","jp2",
+                                  "png","pbm","pgm","ppm","sr","ras",
+                                  "tiff","tif","gif","giff","emf","pct",
+                                  "pcx","pic","pix","vga","wmf"};
+
+const std::string _typeMacro_Video[] = {"mpg","mpeg","avi","wmv","wmp","wm",
+                                  "asf","mpe","m1v","m2v","mpv2","mp2v",
+                                  "dat","ts","tp","tpr","trp","vob","ifo",
+                                  "ogm","ogv","mp4","m4v","m4p","m4b","3gp",
+                                  "3gpp","3g2","3gp2","mkv","rm","ram",
+                                  "rmvb","rpm","flv","swf","mov","qt",
+                                  "amr","nsv","dpg","m2ts","m2t","mts",
+                                  "k3g","skm","evo","nsr","amv","divx","webm"};
+
+const std::string _typeMacro[] = {"image","video","etc"};
+
 //---------------------------------------------------------------------------
 RunSetWrapper::RunSetWrapper(const RunSet* _runset,string _mediaRootPath,
                              ServiceManager *_sman)
@@ -47,7 +63,16 @@ RunSetWrapper::RunSetWrapper(const RunSet* _runset,string _mediaRootPath,
   mFlagIntialize = false;
   mRunset = NULL;
   mMediaRootPath = "";	
-  mServiceMan = NULL;	
+  mServiceMan = NULL;  
+
+  for(int k = 0;k<(sizeof(_typeMacro_Image)/sizeof(_typeMacro_Image[0]));k++)
+    mTypeMacro_Image.push_back(_typeMacro_Image[k]);
+
+  for(int k = 0;k<(sizeof(_typeMacro_Video)/sizeof(_typeMacro_Video[0]));k++)
+    mTypeMacro_Video.push_back(_typeMacro_Video[k]); 
+
+  for(int k = 0;k<(sizeof(_typeMacro)/sizeof(_typeMacro[0]));k++)
+    mTypeMacro.push_back(_typeMacro[k]);
 
   if(_runset)
   {
@@ -83,14 +108,14 @@ RunSetWrapper::~RunSetWrapper()
 
 
 //---------------------------------------------------------------------------
-rsMediaType RunSetWrapper::getType(const string _aPath)
+rsMediaType RunSetWrapper::getTypeMicro(const string _aPath)
 {
-  string tExt = getFileExtension(_aPath);
+  string tExt = getFileExtension(_aPath);  
   return (rsMediaType)tExt;
 }
 
 //---------------------------------------------------------------------------
-rsMediaType RunSetWrapper::getType(const LabelablePtr _pla)
+rsMediaType RunSetWrapper::getTypeMicro(const LabelablePtr _pla)
 {
   rsMediaType tType = "unknown";
 
@@ -104,7 +129,7 @@ rsMediaType RunSetWrapper::getType(const LabelablePtr _pla)
     tAbsFilePath += "/";
     tAbsFilePath += _pla->sub.path.filename;
 
-    return getType(tAbsFilePath);
+    return getTypeMicro(tAbsFilePath);
   }	
 }
 
@@ -157,7 +182,7 @@ bool RunSetWrapper::isInRunset(const string&_rDir,const string& _fname,
 {
   //In future, fileType will be examined by accessing the file itself (not using the extension)
   //So, the directory is remained in this function.
-  _resType = getType(convertToAbsDirectory(_rDir) + "/" + _fname);
+  _resType = getTypeMicro(convertToAbsDirectory(_rDir) + "/" + _fname);
 
   if(_types.empty())
     return true;
@@ -167,7 +192,7 @@ bool RunSetWrapper::isInRunset(const string&_rDir,const string& _fname,
 
 
 //---------------------------------------------------------------------------
-void RunSetWrapper::addToList(const LabelablePtr _pla,const rsMediaType _type, cvac::Purpose purpose)
+void RunSetWrapper::addToList(const LabelablePtr _pla,const rsMediaType _type,cvac::Purpose purpose)
 {
   if(!_pla)
   {
@@ -175,12 +200,47 @@ void RunSetWrapper::addToList(const LabelablePtr _pla,const rsMediaType _type, c
     return;
   }
 
+  //Verify a media type for an original
+  std::string _typeMacro = getTypeMacro(_pla->sub.path.filename);
+  if(_typeMacro.compare(mTypeMacro[0]) == 0)
+  {
+    _pla->sub.isImage = true;
+    _pla->sub.isVideo = false;
+  }
+  else if(_typeMacro.compare(mTypeMacro[1]) == 0)
+  {
+    _pla->sub.isImage = false;
+    _pla->sub.isVideo = true;
+  }
+  else
+  {
+    _pla->sub.isImage = false;
+    _pla->sub.isVideo = false;
+  } 
+
   cvac::Result  _result;
   _result.original = _pla;
   _result.original->lab.hasLabel = true;
   _result.original->lab.name = getPurposeName(purpose);
   mResultSet.results.push_back(_result);
   mResultSetType.push_back(_type);
+}
+
+//---------------------------------------------------------------------------
+std::string RunSetWrapper::getTypeMacro(const std::string& _path)
+{
+  string tExt = getFileExtension(_path);   
+
+  vector<string>::iterator _itr;
+  _itr = std::find(mTypeMacro_Image.begin(),mTypeMacro_Image.end(),tExt);
+  if(_itr!=mTypeMacro_Image.end())
+    return (rsMediaType)mTypeMacro[0];  //for image
+
+  _itr = std::find(mTypeMacro_Video.begin(),mTypeMacro_Video.end(),tExt);
+  if(_itr!=mTypeMacro_Video.end())
+    return (rsMediaType)mTypeMacro[1];  //for video
+  else
+    return (rsMediaType)mTypeMacro[2];  //for etc
 }
 
 //---------------------------------------------------------------------------
@@ -243,10 +303,10 @@ bool RunSetWrapper::makeBasicList()
             //////////////////////////////////////////////////////////////////////////            
             
             //fileExists routine is not working for a symbolic link
-            addToList(in_la,getType(symlinkFullPath), curPurpose);
+            addToList(in_la,getTypeMicro(symlinkFullPath), curPurpose);
             /*            
             if(fileExists(symlinkFullPath)) 
-              addToList(in_la,getType(symlinkFullPath));
+              addToList(in_la,getTypeMicro(symlinkFullPath), curPurpose);
             else	//no file
               continue;
             */
@@ -320,9 +380,7 @@ bool RunSetWrapper::makeBasicList_parse(const string& _absDir,bool _recursive,
         rsMediaType tType;
         if(isInRunset(_rDir,tfname,_types,tType))
         {
-          LabelablePtr tpla = new Labelable();	
-          //tpla->sub.isImage = true; 
-          //tpla->sub.isVideo = false;
+          LabelablePtr tpla = new Labelable();
           tpla->sub.path.filename = tfname;
           tpla->sub.path.directory.relativePath = _rDir;
           addToList(tpla,tType, purpose);


### PR DESCRIPTION
1) RunsetWrapper can fill both variables (isImage and isVideo) of a substrate of the original of a Result according to its file-extension. Based on this information, detector can make a different foundlabels such labelables, LabeledLocations, and LabeledTrakcs.

2) Making a list of supported conversion is simplified.
